### PR TITLE
FEAT: Added throttling for login so that only 10 login requests in an hour

### DIFF
--- a/authentication/api.py
+++ b/authentication/api.py
@@ -1,5 +1,6 @@
 from authentication.schemas import LoginSchema, RegisterSchema, RefreshSchema
 from ninja import Router
+from ninja.throttling import AnonRateThrottle
 from ninja_jwt.tokens import RefreshToken
 from ninja_jwt.exceptions import TokenError
 from ninja.errors import HttpError
@@ -9,7 +10,7 @@ from ninja_jwt.authentication import JWTAuth
 router = Router()
 
 
-@router.post("/login")
+@router.post("/login", throttle=AnonRateThrottle(rate="10/h"))
 def login(request, data: LoginSchema):
     try:
         user = User.objects.get(username=data.phone_number)


### PR DESCRIPTION
This is for security reasons, to block users from requesting login in a spam behavior, or protect the API from being called using bruteforce. For the future, it's better to add captcha in the frontend and provide a locking out of users that have failed the login for multiple times without giving a limit to a person that's actually logging in to their account.