### PR TITLE
TASK-187 Filter Tasks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ django-ninja-jwt
 python-dotenv
 Django
 django-cors-headers
+django-stubs

--- a/tasks/api.py
+++ b/tasks/api.py
@@ -4,6 +4,7 @@ from tasks.schemas import TaskSchema, SortedTaskSchema
 from tasks.services.list_service_impl import ListServiceImpl
 from cycle.services.cycle_service import CycleService
 from ninja.errors import HttpError
+from ninja.pagination import paginate
 from typing import List
 
 router = Router(auth=JWTAuth())
@@ -26,3 +27,8 @@ def list_tasks_sorted(request):
         return tasks
     except:
         raise HttpError(400, "Data tidak ditemukan")
+
+@router.get("/filter", response={200: List[TaskSchema]})
+@paginate
+def filter_tasks(request):
+    return

--- a/tasks/api.py
+++ b/tasks/api.py
@@ -1,10 +1,9 @@
-from ninja import Router
+from ninja import Query, Router
 from ninja_jwt.authentication import JWTAuth
-from tasks.schemas import TaskSchema, SortedTaskSchema
+from tasks.schemas import TaskSchema, SortedTaskSchema, TaskFilterSchema
 from tasks.services.list_service_impl import ListServiceImpl
 from cycle.services.cycle_service import CycleService
 from ninja.errors import HttpError
-from ninja.pagination import paginate
 from typing import List
 
 router = Router(auth=JWTAuth())
@@ -28,7 +27,8 @@ def list_tasks_sorted(request):
     except:
         raise HttpError(400, "Data tidak ditemukan")
 
+
 @router.get("/filter", response={200: List[TaskSchema]})
-@paginate
-def filter_tasks(request):
+def filter_tasks(request, filters: Query[TaskFilterSchema]):
     return
+

--- a/tasks/api.py
+++ b/tasks/api.py
@@ -1,6 +1,7 @@
 from ninja import Query, Router
 from ninja_jwt.authentication import JWTAuth
 from tasks.schemas import TaskSchema, SortedTaskSchema, TaskFilterSchema
+from tasks.services.filter_service_impl import FilterServiceImpl
 from tasks.services.list_service_impl import ListServiceImpl
 from cycle.services.cycle_service import CycleService
 from ninja.errors import HttpError
@@ -30,5 +31,10 @@ def list_tasks_sorted(request):
 
 @router.get("/filter", response={200: List[TaskSchema]})
 def filter_tasks(request, filters: Query[TaskFilterSchema]):
-    return
+    try:
+        cycle = CycleService.get_active_cycle(request.auth)
+        tasks = FilterServiceImpl.filter_tasks(cycle.id, filters.period.value if filters.period else None, filters.assignee)
+        return tasks[filters.offset : filters.offset + filters.limit]
+    except:
+        raise HttpError(400, "Data tidak ditemukan")
 

--- a/tasks/enums.py
+++ b/tasks/enums.py
@@ -17,3 +17,9 @@ class TaskType(enum.Enum):
     @classmethod
     def choices(cls):
         return [(key.value, key.name) for key in cls]
+
+class TaskPeriod(enum.Enum):
+    TODAY = "today"
+    UPCOMING = "upcoming"
+    PAST = "past"
+

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -4,7 +4,7 @@ from tasks.enums import TaskStatus, TaskType
 from cycle.models import Cycle
 
 class TaskTemplate(models.Model):
-    task_type = models.CharField(max_length=20, choices=TaskType.choices)
+    task_type = models.CharField(max_length=20, choices=TaskType.choices())
     day_of_culture = models.PositiveIntegerField()
 
     class Meta:
@@ -13,9 +13,9 @@ class TaskTemplate(models.Model):
 
 class Task(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    task_type = models.CharField(max_length=20, choices=TaskType.choices)
+    task_type = models.CharField(max_length=20, choices=TaskType.choices())
     date = models.DateField()
-    status = models.CharField(max_length=4, choices=TaskStatus.choices, default=TaskStatus.TODO)
+    status = models.CharField(max_length=4, choices=TaskStatus.choices(), default=TaskStatus.TODO.value)
     cycle = models.ForeignKey(Cycle, on_delete=models.CASCADE)
     assignee = models.CharField(max_length=13, blank=True)
 

--- a/tasks/repositories/filter_repo.py
+++ b/tasks/repositories/filter_repo.py
@@ -1,5 +1,23 @@
+from django.utils.timezone import now
+
+from tasks.models import Task
+
+
 class FilterRepo:
     @staticmethod
     def filter_tasks(period: str = "today", assignee_username: str = ""):
-        return
+        filters = {}
+        today = now().date()
+
+        if period == "today":
+            filters['date'] = today
+        elif period == "upcoming":
+            filters['date__gt'] = today
+        elif period == "past":
+            filters['date__lt'] = today
+
+        if assignee_username:
+            filters['assignee'] = assignee_username
+
+        return Task.objects.filter(**filters)
 

--- a/tasks/repositories/filter_repo.py
+++ b/tasks/repositories/filter_repo.py
@@ -1,0 +1,5 @@
+class FilterRepo:
+    @staticmethod
+    def filter_tasks(period: str = "today", assignee_username: str = ""):
+        return
+

--- a/tasks/repositories/filter_repo.py
+++ b/tasks/repositories/filter_repo.py
@@ -4,7 +4,7 @@ from tasks.models import Task
 
 class FilterRepo:
     @staticmethod
-    def filter_tasks(cycle_id: str, period: str = "today", assignee_username: str = ""):
+    def filter_tasks(cycle_id: str, period: str|None = None, assignee_username: str|None = None):
         filters = {}
         today = now().date()
 

--- a/tasks/repositories/filter_repo.py
+++ b/tasks/repositories/filter_repo.py
@@ -1,11 +1,10 @@
 from django.utils.timezone import now
-
 from tasks.models import Task
 
 
 class FilterRepo:
     @staticmethod
-    def filter_tasks(period: str = "today", assignee_username: str = ""):
+    def filter_tasks(cycle_id: str, period: str = "today", assignee_username: str = ""):
         filters = {}
         today = now().date()
 
@@ -19,5 +18,5 @@ class FilterRepo:
         if assignee_username:
             filters['assignee'] = assignee_username
 
-        return Task.objects.filter(**filters)
+        return Task.objects.filter(**filters, cycle_id=cycle_id)
 

--- a/tasks/repositories/list_repo.py
+++ b/tasks/repositories/list_repo.py
@@ -9,7 +9,8 @@ class ListRepo:
     @staticmethod
     def list_past_tasks(cycle_id: str):
         return Task.objects.filter(cycle_id=cycle_id, date__lt=timezone.now().date())
-    
+
     @staticmethod
     def list_upcoming_tasks(cycle_id: str):
         return Task.objects.filter(cycle_id=cycle_id, date__gte=timezone.now().date())
+

--- a/tasks/schemas.py
+++ b/tasks/schemas.py
@@ -4,6 +4,8 @@ from datetime import date
 from typing import Optional
 from typing import List
 
+from tasks.enums import TaskPeriod
+
 class TaskSchema(Schema):
     id: UUID4
     task_type: str
@@ -20,3 +22,10 @@ class TaskSchema(Schema):
 class SortedTaskSchema(Schema):
     past: List[TaskSchema]
     upcoming: List[TaskSchema]
+
+
+class TaskFilterSchema(Schema):
+    limit: int = 10
+    offset: int = 0
+    period: Optional[TaskPeriod] = None
+    assignee: Optional[str] = None

--- a/tasks/services/filter_service.py
+++ b/tasks/services/filter_service.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+from django.db.models import QuerySet
+
+class FilterService(ABC):
+    @staticmethod
+    @abstractmethod
+    def filter_tasks(period: str = "today", assignee_username: str = "") -> QuerySet:
+        """Filter tasks by period and assignee"""

--- a/tasks/services/filter_service.py
+++ b/tasks/services/filter_service.py
@@ -5,5 +5,5 @@ from django.db.models import QuerySet
 class FilterService(ABC):
     @staticmethod
     @abstractmethod
-    def filter_tasks(period: str = "today", assignee_username: str = "") -> QuerySet:
+    def filter_tasks(cycle_id: str, period: str = "today", assignee_username: str = "") -> QuerySet:
         """Filter tasks by period and assignee"""

--- a/tasks/services/filter_service.py
+++ b/tasks/services/filter_service.py
@@ -5,5 +5,5 @@ from django.db.models import QuerySet
 class FilterService(ABC):
     @staticmethod
     @abstractmethod
-    def filter_tasks(cycle_id: str, period: str = "today", assignee_username: str = "") -> QuerySet:
+    def filter_tasks(cycle_id: str, period: str|None = None, assignee_username: str|None = None) -> QuerySet:
         """Filter tasks by period and assignee"""

--- a/tasks/services/filter_service_impl.py
+++ b/tasks/services/filter_service_impl.py
@@ -4,5 +4,5 @@ from tasks.services.filter_service import FilterService
 
 class FilterServiceImpl(FilterService):
     @staticmethod
-    def filter_tasks(cycle_id, period = "today", assignee_username = ""):
+    def filter_tasks(cycle_id, period = None, assignee_username = None):
         return FilterRepo.filter_tasks(cycle_id=cycle_id, period=period, assignee_username=assignee_username)

--- a/tasks/services/filter_service_impl.py
+++ b/tasks/services/filter_service_impl.py
@@ -1,7 +1,8 @@
+from tasks.repositories.filter_repo import FilterRepo
 from tasks.services.filter_service import FilterService
 
 
 class FilterServiceImpl(FilterService):
     @staticmethod
     def filter_tasks(period = "today", assignee_username = ""):
-        return
+        return FilterRepo.filter_tasks(period=period, assignee_username=assignee_username)

--- a/tasks/services/filter_service_impl.py
+++ b/tasks/services/filter_service_impl.py
@@ -4,5 +4,5 @@ from tasks.services.filter_service import FilterService
 
 class FilterServiceImpl(FilterService):
     @staticmethod
-    def filter_tasks(period = "today", assignee_username = ""):
-        return FilterRepo.filter_tasks(period=period, assignee_username=assignee_username)
+    def filter_tasks(cycle_id, period = "today", assignee_username = ""):
+        return FilterRepo.filter_tasks(cycle_id=cycle_id, period=period, assignee_username=assignee_username)

--- a/tasks/services/filter_service_impl.py
+++ b/tasks/services/filter_service_impl.py
@@ -1,0 +1,7 @@
+from tasks.services.filter_service import FilterService
+
+
+class FilterServiceImpl(FilterService):
+    @staticmethod
+    def filter_tasks(period = "today", assignee_username = ""):
+        return

--- a/tasks/services/list_service.py
+++ b/tasks/services/list_service.py
@@ -1,9 +1,11 @@
 from abc import ABC, abstractmethod
 
+from django.db.models import QuerySet
+
 class ListService(ABC):
     @staticmethod
     @abstractmethod
-    def list_tasks(cycle_id: str):
+    def list_tasks(cycle_id: str) -> QuerySet:
         """List all tasks for a given cycle"""
 
     @staticmethod

--- a/tasks/tests/api/test_filter_api.py
+++ b/tasks/tests/api/test_filter_api.py
@@ -1,0 +1,96 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.test import TestCase
+from unittest.mock import patch, MagicMock
+
+from ninja.errors import HttpError
+from cycle.models import Cycle
+from tasks.api import filter_tasks
+from tasks.enums import TaskPeriod
+from tasks.models import Task
+from django.utils import timezone
+from datetime import timedelta
+from django.http import HttpRequest
+import uuid
+
+from tasks.schemas import TaskFilterSchema
+
+class TestTaskFilterAPI(TestCase):
+    def setUp(self):
+        self.task1 = MagicMock(Task)
+        self.task1.id = uuid.uuid4()
+        self.task1.assignee = "Rafi"
+        self.task1.date = timezone.now().date() - timedelta(days=1)
+
+        self.task2 = MagicMock(Task)
+        self.task2.id = uuid.uuid4()
+        self.task2.assignee = "Rafi"
+        self.task2.date = timezone.now().date()
+
+        self.task3 = MagicMock(Task)
+        self.task3.id = uuid.uuid4()
+        self.task3.assignee = "Rafi"
+        self.task3.date = timezone.now().date() + timedelta(days=1)
+
+        self.task4 = MagicMock(Task)
+        self.task4.id = uuid.uuid4()
+        self.task4.assignee = "Rafli"
+        self.task4.date = timezone.now().date() + timedelta(days=1)
+
+        self.cycle = MagicMock(spec=Cycle)
+        self.cycle.id = uuid.uuid4()
+
+        self.task_repository = [self.task1, self.task2, self.task3, self.task4]
+
+    def test_filter_tasks_api(self):
+        with patch('tasks.services.filter_service_impl.FilterServiceImpl.filter_tasks') as mock_filter, \
+            patch('cycle.services.cycle_service.CycleService.get_active_cycle') as mock_cycle:
+
+            filters = TaskFilterSchema(period=None, assignee="Rafi")
+            filtered_tasks = [task for task in self.task_repository if task.assignee == filters.assignee]
+
+            mock_cycle.return_value = self.cycle
+            mock_filter.return_value = filtered_tasks
+            mock_request = MagicMock(spec=HttpRequest)
+            mock_request.auth = MagicMock(spec=User)
+
+            expected_response = filtered_tasks[filters.offset : filters.offset + filters.limit]
+
+            response = filter_tasks(mock_request, filters)
+            self.assertEqual(response, expected_response)
+
+
+    def test_filter_tasks_api_with_period(self):
+        with patch('tasks.services.filter_service_impl.FilterServiceImpl.filter_tasks') as mock_filter, \
+            patch('cycle.services.cycle_service.CycleService.get_active_cycle') as mock_cycle:
+
+            filters = TaskFilterSchema(period=TaskPeriod.UPCOMING, assignee="Rafi")
+            filtered_tasks = [task for task in self.task_repository if task.assignee == filters.assignee]
+
+            mock_cycle.return_value = self.cycle
+            mock_filter.return_value = filtered_tasks
+            mock_request = MagicMock(spec=HttpRequest)
+            mock_request.auth = MagicMock(spec=User)
+
+            expected_response = filtered_tasks[filters.offset : filters.offset + filters.limit]
+
+            response = filter_tasks(mock_request, filters)
+            self.assertEqual(response, expected_response)
+
+
+    def test_filter_tasks_cycle_not_found(self):
+        with patch('tasks.services.filter_service_impl.FilterServiceImpl.filter_tasks') as mock_filter, \
+            patch('cycle.services.cycle_service.CycleService.get_active_cycle') as mock_cycle:
+
+            filters = TaskFilterSchema(period=TaskPeriod.UPCOMING, assignee="Rafi")
+            filtered_tasks = [task for task in self.task_repository if task.assignee == filters.assignee]
+
+            mock_cycle.return_value = None
+            mock_filter.return_value = filtered_tasks
+            mock_request = MagicMock(spec=HttpRequest)
+            mock_request.auth = MagicMock(spec=User)
+
+            with self.assertRaises(HttpError) as context:
+                filter_tasks(mock_request, filters)
+                self.assertEqual(context.exception.message, "Data tidak ditemukan")
+

--- a/tasks/tests/repositories/test_filter_repo.py
+++ b/tasks/tests/repositories/test_filter_repo.py
@@ -35,28 +35,28 @@ class TestFilterRepo(TestCase):
     def test_filter_tasks_by_assignee(self, mock_filter):
         assignee = "Rafi"
         mock_filter.return_value = [task for task in self.task_repository if task.assignee == assignee]
-        tasks = FilterRepo.filter_tasks(assignee_username=assignee)
+        tasks = FilterRepo.filter_tasks(cycle_id='test',assignee_username=assignee)
         self.assertEqual(tasks, mock_filter.return_value)
 
     @patch('tasks.models.Task.objects.filter')
     def test_filter_tasks_by_period(self, mock_filter):
         period = "today"
         mock_filter.return_value = [task for task in self.task_repository if task.date == timezone.now().date()]
-        tasks = FilterRepo.filter_tasks(period=period)
+        tasks = FilterRepo.filter_tasks(cycle_id='test', period=period)
         self.assertEqual(tasks, mock_filter.return_value)
 
     @patch('tasks.models.Task.objects.filter')
     def test_filter_tasks_by_period_past(self, mock_filter):
         period = "past"
         mock_filter.return_value = [task for task in self.task_repository if task.date < timezone.now().date()]
-        tasks = FilterRepo.filter_tasks(period=period)
+        tasks = FilterRepo.filter_tasks(cycle_id='test', period=period)
         self.assertEqual(tasks, mock_filter.return_value)
 
     @patch('tasks.models.Task.objects.filter')
     def test_filter_tasks_by_period_upcoming(self, mock_filter):
         period = "upcoming"
         mock_filter.return_value = [task for task in self.task_repository if task.date > timezone.now().date()]
-        tasks = FilterRepo.filter_tasks(period=period)
+        tasks = FilterRepo.filter_tasks(cycle_id='test', period=period)
         self.assertEqual(tasks, mock_filter.return_value)
 
     @patch('tasks.models.Task.objects.filter')
@@ -64,6 +64,6 @@ class TestFilterRepo(TestCase):
         assignee = "Rafi"
         period = "today"
         mock_filter.return_value = [task for task in self.task_repository if task.assignee == assignee and task.date == timezone.now().date()]
-        tasks = FilterRepo.filter_tasks(assignee_username=assignee, period=period)
+        tasks = FilterRepo.filter_tasks(cycle_id='test', assignee_username=assignee, period=period)
         self.assertEqual(tasks, mock_filter.return_value)
 

--- a/tasks/tests/repositories/test_filter_repo.py
+++ b/tasks/tests/repositories/test_filter_repo.py
@@ -1,0 +1,55 @@
+from datetime import timedelta
+from django.test import TestCase
+from unittest.mock import patch, MagicMock
+from tasks.repositories.filter_repo import FilterRepo
+from tasks.models import Task
+from django.utils import timezone
+import uuid
+
+class TestFilterRepo(TestCase):
+    def setUp(self):
+        self.task1 = MagicMock(Task)
+        self.task1.id = uuid.uuid4()
+        self.task1.assignee = "Rafi"
+        self.task1.date = timezone.now().date() - timedelta(days=1)
+
+        self.task2 = MagicMock(Task)
+        self.task2.id = uuid.uuid4()
+        self.task2.assignee = "Rafi"
+        self.task2.date = timezone.now().date()
+
+        self.task3 = MagicMock(Task)
+        self.task3.id = uuid.uuid4()
+        self.task3.assignee = "Rafi"
+        self.task3.date = timezone.now().date() + timedelta(days=1)
+
+        self.task4 = MagicMock(Task)
+        self.task4.id = uuid.uuid4()
+        self.task4.assignee = "Rafli"
+        self.task4.date = timezone.now().date() + timedelta(days=1)
+
+        self.task_repository = [self.task1, self.task2, self.task3, self.task4]
+
+
+    @patch('tasks.models.Task.objects.filter')
+    def test_filter_tasks_by_assignee(self, mock_filter):
+        assignee = "Rafi"
+        mock_filter.return_value = [task for task in self.task_repository if task.assignee == assignee]
+        tasks = FilterRepo.filter_tasks(assignee_username=assignee)
+        self.assertEqual(tasks, mock_filter.return_value)
+
+    @patch('tasks.models.Task.objects.filter')
+    def test_filter_tasks_by_period(self, mock_filter):
+        period = "today"
+        mock_filter.return_value = [task for task in self.task_repository if task.date == timezone.now().date()]
+        tasks = FilterRepo.filter_tasks(period=period)
+        self.assertEqual(tasks, mock_filter.return_value)
+
+    @patch('tasks.models.Task.objects.filter')
+    def test_filter_tasks_by_assignee_and_period(self, mock_filter):
+        assignee = "Rafi"
+        period = "today"
+        mock_filter.return_value = [task for task in self.task_repository if task.assignee == assignee and task.date == timezone.now().date()]
+        tasks = FilterRepo.filter_tasks(assignee_username=assignee, period=period)
+        self.assertEqual(tasks, mock_filter.return_value)
+

--- a/tasks/tests/repositories/test_filter_repo.py
+++ b/tasks/tests/repositories/test_filter_repo.py
@@ -46,6 +46,20 @@ class TestFilterRepo(TestCase):
         self.assertEqual(tasks, mock_filter.return_value)
 
     @patch('tasks.models.Task.objects.filter')
+    def test_filter_tasks_by_period_past(self, mock_filter):
+        period = "past"
+        mock_filter.return_value = [task for task in self.task_repository if task.date < timezone.now().date()]
+        tasks = FilterRepo.filter_tasks(period=period)
+        self.assertEqual(tasks, mock_filter.return_value)
+
+    @patch('tasks.models.Task.objects.filter')
+    def test_filter_tasks_by_period_upcoming(self, mock_filter):
+        period = "upcoming"
+        mock_filter.return_value = [task for task in self.task_repository if task.date > timezone.now().date()]
+        tasks = FilterRepo.filter_tasks(period=period)
+        self.assertEqual(tasks, mock_filter.return_value)
+
+    @patch('tasks.models.Task.objects.filter')
     def test_filter_tasks_by_assignee_and_period(self, mock_filter):
         assignee = "Rafi"
         period = "today"

--- a/tasks/tests/services/test_filter_service.py
+++ b/tasks/tests/services/test_filter_service.py
@@ -35,6 +35,6 @@ class TestFilterService(TestCase):
     @patch('tasks.repositories.filter_repo.FilterRepo.filter_tasks')
     def test_filter_tasks(self, mock_filter):
         mock_filter.return_value = [task for task in self.task_repository if task.assignee == "Rafi"]
-        tasks = FilterServiceImpl.filter_tasks(assignee_username="Rafi")
+        tasks = FilterServiceImpl.filter_tasks(cycle_id='1', assignee_username="Rafi")
         self.assertEqual(tasks, mock_filter.return_value)
 

--- a/tasks/tests/services/test_filter_service.py
+++ b/tasks/tests/services/test_filter_service.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from unittest.mock import patch, MagicMock
+from tasks.models import Task
+from django.utils import timezone
+from datetime import timedelta
+from tasks.services.filter_service_impl import FilterServiceImpl
+import uuid
+
+
+class TestFilterService(TestCase):
+    def setUp(self):
+        self.task1 = MagicMock(Task)
+        self.task1.id = uuid.uuid4()
+        self.task1.assignee = "Rafi"
+        self.task1.date = timezone.now().date() - timedelta(days=1)
+
+        self.task2 = MagicMock(Task)
+        self.task2.id = uuid.uuid4()
+        self.task2.assignee = "Rafi"
+        self.task2.date = timezone.now().date()
+
+        self.task3 = MagicMock(Task)
+        self.task3.id = uuid.uuid4()
+        self.task3.assignee = "Rafi"
+        self.task3.date = timezone.now().date() + timedelta(days=1)
+
+        self.task4 = MagicMock(Task)
+        self.task4.id = uuid.uuid4()
+        self.task4.assignee = "Rafli"
+        self.task4.date = timezone.now().date() + timedelta(days=1)
+
+        self.task_repository = [self.task1, self.task2, self.task3, self.task4]
+
+
+    @patch('tasks.repositories.filter_repo.FilterRepo.filter_tasks')
+    def test_filter_tasks(self, mock_filter):
+        mock_filter.return_value = [task for task in self.task_repository if task.assignee == "Rafi"]
+        tasks = FilterServiceImpl.filter_tasks(assignee_username="Rafi")
+        self.assertEqual(tasks, mock_filter.return_value)
+


### PR DESCRIPTION
<img width="770" alt="Screenshot 2024-11-24 at 00 39 55" src="https://github.com/user-attachments/assets/e8b5e86a-e1ab-4b1a-84a7-e71efce854e7">


In this pull request, I added couple of things to help improve the user experience in the frontend. Key things I implemented include:

- Filtering tasks by assignee
- Filtering tasks by period
- Enable offsetting and limiting on the API
- Added `django-stubs` in requirements.txt (this is a plugin to assist my nvim setup hehe)
- Tests covered 100% of the code

To filter, limit, or offset the response, you can add a query parameter, e.g.
`/api/tasks/filter?period=past` or if you want to combine query parameters you can just add a `&` sign, such as `/api/tasks/filter?period=past&offset=10`.  

The filter query parameters are optional, thus if you do not input anything, it will not filter. However, the offset and limit parameters are defaulted to 0 and 10, respectively. To further clarify, the valid query parameters and their definitions are as follows:
- `period`: Filters tasks by period, e.g., past, today, and upcoming.
- `assignee`: Filters tasks by the assignee's username.
- `offset`: Specifies the starting point for the response (i.e., how many tasks to skip). The default value is 0, meaning no tasks are skipped.
- `limit`: Limits the number of tasks returned in the response. The default value is 10, so if no limit is specified, only the first 10 tasks are returned.

If you guys have trouble after installing the `django-stubs` plugin, let me know, and we can remove it from the requirements file. Additionally, feel free to provide any feedback to my code.

Best regards,
Rafi